### PR TITLE
Revert "feat: Store images in memory instead of on disk(#11)"

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13,7 +13,7 @@ class ImageCLI(object):
         sys.exit() if is_fatal else None
 
     def parse_arguments(self):
-        command, filename, parameters = "", {}
+        command, parameters = "", {}
         for index, argument in enumerate(sys.argv[1:]):
             if index == 0:
                 command = argument

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 black==21.9b0
 click==8.0.1
+Colr==0.9.1
 pathspec==0.9.0
 Pillow==8.3.2
 regex==2021.9.24


### PR DESCRIPTION
This reverts commit 997944cc9be313e437826d239701fe76c3e395db.

As discussed on #11, this commit implements a change that should be reversed.

Also, this commit is best reverted for a Pull Request from [`AnonymouX47:redesign`](https://github.com/AnonymouX47/img/tree/redesign) to be succesfully merged in without conflicts.
I already tested it locally, without reverting this commit, the conflicts are quite much.
Of course, the conflicts can be resolved but why not avoid them all together.

After all, we don't want the in-memory design anymore. :smiley:

`image.py` is the file of conflict.
I checked the changes in other files, they are either not complete or can easily be redone.
